### PR TITLE
fix `TypeError: Cannot read property split of undefined` on installing a package

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -99,6 +99,7 @@ const install = function (packageName, registry, namespace, save, cluster, dirPa
         return listDirs(nodeModulesPath);
     }).then(dirs => {
         return Promise.each(dirs, function(dir) {
+            dirs = dirs.filter(dir => dir != undefined)
             if (dir.split("/").slice(-1)[0].startsWith("@")) {
                 return listDirs(dir).then(innerDirs => {
                     return Promise.each(innerDirs, function(innerDir) {


### PR DESCRIPTION
- `listDir` in `utils.js` func used to return undefined for a file, we filtered the returned map only for directories