### PR TITLE
fix split on undefined

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -98,7 +98,7 @@ const install = function (packageName, registry, namespace, save, cluster, dirPa
         }
         return listDirs(nodeModulesPath);
     }).then(dirs => {
-		dirs = dirs.filter(dir => dir != undefined)
+        dirs = dirs.filter(dir => dir != undefined)
         return Promise.each(dirs, function(dir) {
             if (dir.split("/").slice(-1)[0].startsWith("@")) {
                 return listDirs(dir).then(innerDirs => {


### PR DESCRIPTION
The filter is supposed to be applied before `return Promise.each(dirs, function(dir) {...})`