### PR TITLE
[dataflow] Add support for (install, uninstall, list, info) commands

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -54,7 +54,7 @@ yargs.command({
         command: 'info <package> [template]',
         desc: 'Get info of the installed package or a specific template in the package',
         handler: (argv) => {
-            info(argv.namespace, argv.package, argv.cluster).then(argoPackage => {
+            info(argv.namespace, argv.package, argv.cluster, argv.pipeline).then(argoPackage => {
                 if (argv.template) {
                     return argoPackage.templateInfo(argv.template)
                 }
@@ -90,7 +90,7 @@ yargs.command({
         aliases: ['u', 'r'],
         desc: 'Uninstall a package. Uninstalls all dependencies associated with the package.',
         handler: (argv) => {
-            uninstall(argv.namespace, argv.package, argv.cluster).then(_ => {
+            uninstall(argv.namespace, argv.package, argv.cluster, argv.pipeline).then(_ => {
                 console.log(`Successfully deleted package ${argv.package}`)
             });
         }
@@ -117,7 +117,7 @@ yargs.command({
         aliases: ['l'],
         desc: 'List all the packages installed in the namespace',
         handler: (argv) => {
-            list(argv.namespace, argv.cluster).then(argoPackages => {
+            list(argv.namespace, argv.cluster, argv.pipeline).then(argoPackages => {
                 if (argoPackages.length === 0) {
                     console.log("No packages found");
                     return
@@ -142,6 +142,12 @@ yargs.command({
         type: 'string',
         description: 'Argo Package Registry',
         default: "https://marketplace.atlan.com"
+    })
+    .option('pipeline', {
+        alias: 'p',
+        type: 'boolean',
+        description: 'Enable Argo Pipeline type',
+        default: false
     })
     .option('cluster', {
         alias: 'c',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,11 +10,16 @@ class Constants {
     ARGOPM_INSTALLER_LABEL = "org.argopm.package.installer"
     ARGOPM_INSTALLER_LABEL_VALUE = "argopm"
 
+    // workflow
     ARGO_K8S_API_GROUP = "argoproj.io"
     ARGO_K8S_API_VERSION = "v1alpha1"
     ARGO_WORKFLOW_TEMPLATES_PLURAL = "workflowtemplates"
     ARGO_CLUSTER_WORKFLOW_TEMPLATES_PLURAL = "clusterworkflowtemplates"
     ARGO_WORKFLOWS_PLURAL = "workflows"
+
+    // dataflow
+    ARGO_DATAFLOW_K8S_API_GROUP = "dataflow.argoproj.io"
+    ARGO_PIPELINES_PLURAL = "pipelines"
 }
 
 exports.constants = new Constants();

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,8 @@ exports.info = Package.info;
  * @param {String} name
  * @param {String} cluster
  */
-exports.uninstall = function(namespace, name, cluster) {
-    return Package.info(namespace, name, cluster).then(argoPackage => {
+exports.uninstall = function(namespace, name, cluster, isPipeline) {
+    return Package.info(namespace, name, cluster, isPipeline).then(argoPackage => {
         return argoPackage.delete(cluster);
     })
 }

--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -1,4 +1,5 @@
 // ./lib/k8s.js
+const constants = require("./constants").constants;
 const Promise = require("bluebird");
 const fs = Promise.promisifyAll(require("fs"));
 const yaml = require("js-yaml");
@@ -129,13 +130,19 @@ class K8sInstaller {
      */
     upsertTemplate(namespace, plural, yamlObject, packageName, cluster) {
         var mainThis = this
+
+        var K8S_API_GROUP = ARGO_K8S_API_GROUP;
+        if(yamlObject['kind'] == "Pipeline") {
+            K8S_API_GROUP = constants.ARGO_DATAFLOW_K8S_API_GROUP
+        }
+
         if (!cluster) {
-            return customK8sApi.listNamespacedCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, namespace, plural, 
+            return customK8sApi.listNamespacedCustomObject(K8S_API_GROUP, ARGO_K8S_API_VERSION, namespace, plural, 
                 null, null, null, PackageInfo.getPackageLabel(packageName)).then(response => {
-                    return mainThis.handleTemplateResponse(response, namespace, plural, yamlObject, cluster)
+                    return mainThis.handleTemplateResponse(response, namespace, plural, yamlObject, cluster, K8S_API_GROUP)
             })
         }
-        return customK8sApi.listClusterCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, plural, 
+        return customK8sApi.listClusterCustomObject(K8S_API_GROUP, ARGO_K8S_API_VERSION, plural, 
             null, null, null, PackageInfo.getPackageLabel(packageName)).then(response => {
                 var templateIndex = -1;
                 yamlObject['spec']['templates'].forEach(template => {
@@ -150,11 +157,11 @@ class K8sInstaller {
                         })
                     }
                 })
-                return mainThis.handleTemplateResponse(response, namespace, plural, yamlObject, cluster)
+                return mainThis.handleTemplateResponse(response, namespace, plural, yamlObject, cluster, K8S_API_GROUP)
         })
     }
 
-    handleTemplateResponse(response, namespace, plural, yamlObject, cluster) {
+    handleTemplateResponse(response, namespace, plural, yamlObject, cluster, apiGroup) {
         const name = yamlObject.metadata.name;
         const items = response.body.items;
         let isPresent = false;
@@ -168,15 +175,15 @@ class K8sInstaller {
         if (isPresent) {
             console.debug(`${name} already present in the cluster. Updating it.`)
             if (cluster) {
-                return customK8sApi.patchClusterCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, plural, name, yamlObject, undefined, undefined, undefined, {headers: { 'content-type': 'application/merge-patch+json' }})
+                return customK8sApi.patchClusterCustomObject(apiGroup, ARGO_K8S_API_VERSION, plural, name, yamlObject, undefined, undefined, undefined, {headers: { 'content-type': 'application/merge-patch+json' }})
             }
-            return customK8sApi.patchNamespacedCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, namespace, plural, name, yamlObject, undefined, undefined, undefined, {headers: { 'content-type': 'application/merge-patch+json' }})
+            return customK8sApi.patchNamespacedCustomObject(apiGroup, ARGO_K8S_API_VERSION, namespace, plural, name, yamlObject, undefined, undefined, undefined, {headers: { 'content-type': 'application/merge-patch+json' }})
         }
 
         if (cluster) {
-            return customK8sApi.createClusterCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, plural, yamlObject);    
+            return customK8sApi.createClusterCustomObject(apiGroup, ARGO_K8S_API_VERSION, plural, yamlObject);
         }
-        return customK8sApi.createNamespacedCustomObject(ARGO_K8S_API_GROUP, ARGO_K8S_API_VERSION, namespace, plural, yamlObject);
+        return customK8sApi.createNamespacedCustomObject(apiGroup, ARGO_K8S_API_VERSION, namespace, plural, yamlObject);
     }
 
     /**

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -29,6 +29,13 @@ class Package {
         this.isExecutable = !!this.spec.entrypoint;
         this.arguments = new Argument(this.spec.arguments);
         this.templates = Template.generate(this.spec.templates);
+        this.k8sApiGroup = constants.ARGO_K8S_API_GROUP
+        this.argoTemplatePlural = constants.ARGO_WORKFLOW_TEMPLATES_PLURAL
+
+        if (k8sYaml.kind == "Pipeline") {
+            this.k8sApiGroup = constants.ARGO_DATAFLOW_K8S_API_GROUP
+            this.argoTemplatePlural = constants.ARGO_PIPELINES_PLURAL
+        }
     }
 
     packageInfo() {
@@ -95,9 +102,9 @@ class Package {
                     constants.ARGO_CLUSTER_WORKFLOW_TEMPLATES_PLURAL, capturedThis.metadata.name
                 );
             }
-            return customK8sApi.deleteNamespacedCustomObject(constants.ARGO_K8S_API_GROUP,
+            return customK8sApi.deleteNamespacedCustomObject(capturedThis.k8sApiGroup,
                 constants.ARGO_K8S_API_VERSION, capturedThis.metadata.namespace,
-                constants.ARGO_WORKFLOW_TEMPLATES_PLURAL, capturedThis.metadata.name
+                capturedThis.argoTemplatePlural, capturedThis.metadata.name
             );
         }).then(_ => {
             if (cluster) return []
@@ -123,8 +130,8 @@ class Package {
                     return this.getDependentPackagesFromListResponse(response)
                 })
         }
-        return customK8sApi.listNamespacedCustomObject(constants.ARGO_K8S_API_GROUP, constants.ARGO_K8S_API_VERSION,
-            this.metadata.namespace, constants.ARGO_WORKFLOW_TEMPLATES_PLURAL, null, null, null, this.info.getDependencyLabel()).then(response => {
+        return customK8sApi.listNamespacedCustomObject(this.k8sApiGroup, constants.ARGO_K8S_API_VERSION,
+            this.metadata.namespace, this.argoTemplatePlural, null, null, null, this.info.getDependencyLabel()).then(response => {
             return this.getDependentPackagesFromListResponse(response)
         })
     }
@@ -226,7 +233,13 @@ Package.getInstallerLabel = function () {
  * @param {Boolean} cluster
  * @returns {Promise<Package>}
  */
-Package.info = function (namespace, packageName, cluster) {
+Package.info = function (namespace, packageName, cluster, isPipeline) {
+    var K8S_API_GROUP = constants.ARGO_K8S_API_GROUP, ARGO_TEMPLATE_PLURAL = constants.ARGO_WORKFLOWS_PLURAL;
+    if (isPipeline) {
+        K8S_API_GROUP = constants.ARGO_DATAFLOW_K8S_API_GROUP
+        ARGO_TEMPLATE_PLURAL = constants.ARGO_PIPELINES_PLURAL
+    }
+
     if (cluster) {
         return customK8sApi.listClusterCustomObject(constants.ARGO_K8S_API_GROUP, constants.ARGO_K8S_API_VERSION, 
             constants.ARGO_CLUSTER_WORKFLOW_TEMPLATES_PLURAL, null, null, null, PackageInfo.getPackageLabel(packageName)).then(response => {
@@ -237,8 +250,8 @@ Package.info = function (namespace, packageName, cluster) {
                 return new Package(items[0]);
         })
     }
-    return customK8sApi.listNamespacedCustomObject(constants.ARGO_K8S_API_GROUP, constants.ARGO_K8S_API_VERSION, 
-        namespace, constants.ARGO_WORKFLOW_TEMPLATES_PLURAL, null, null, null, PackageInfo.getPackageLabel(packageName)).then(response => {
+    return customK8sApi.listNamespacedCustomObject(K8S_API_GROUP, constants.ARGO_K8S_API_VERSION, 
+        namespace, ARGO_TEMPLATE_PLURAL, null, null, null, PackageInfo.getPackageLabel(packageName)).then(response => {
             const items = response.body.items;
             if (items.length !== 1) {
                 throw new Error(`${packageName} not found in namespace ${namespace}`)
@@ -253,15 +266,22 @@ Package.info = function (namespace, packageName, cluster) {
  * @param {Boolean} cluster
  * @returns {Promise<[Package]>}
  */
-Package.list = function (namespace, cluster) {
+Package.list = function (namespace, cluster, isPipeline) {
+    var K8S_API_GROUP = constants.ARGO_K8S_API_GROUP, ARGO_TEMPLATE_PLURAL = constants.ARGO_WORKFLOWS_PLURAL;
+
+    if (isPipeline) {
+        K8S_API_GROUP = constants.ARGO_DATAFLOW_K8S_API_GROUP
+        ARGO_TEMPLATE_PLURAL = constants.ARGO_PIPELINES_PLURAL
+    }
+
     if (cluster) {
         return customK8sApi.listClusterCustomObject(constants.ARGO_K8S_API_GROUP, constants.ARGO_K8S_API_VERSION, 
             constants.ARGO_CLUSTER_WORKFLOW_TEMPLATES_PLURAL, null, null, null, Package.getInstallerLabel()).then(response => {
             return handleListResponse(response);
         })
     }
-    return customK8sApi.listNamespacedCustomObject(constants.ARGO_K8S_API_GROUP, constants.ARGO_K8S_API_VERSION,
-        namespace, constants.ARGO_WORKFLOW_TEMPLATES_PLURAL, null, null, null, Package.getInstallerLabel()).then(response => {
+    return customK8sApi.listNamespacedCustomObject(K8S_API_GROUP, constants.ARGO_K8S_API_VERSION,
+        namespace, ARGO_TEMPLATE_PLURAL, null, null, null, Package.getInstallerLabel()).then(response => {
             return handleListResponse(response);
     })
 }


### PR DESCRIPTION
Commands supported:

```
// install - uses `kind` to determine apiGroup
argopm install . -n argo-dataflow-system

// uninstall - uses `-p` flag to determine apiGroup and templateGroup
argopm uninstall @atlan/heka-redis-sync-rt -p -n argo-dataflow-system

// list - uses `-p` flag to determine apiGroup and templateGroup
argopm list -p -n argo-dataflow-system

// info - uses `-p` flag to determine apiGroup and templateGroup
argopm info @atlan/heka-redis-sync-rt -p -n argo-dataflow-system

```