### PR TITLE
Fix labels cannot have . as value

### DIFF
--- a/lib/models/info.js
+++ b/lib/models/info.js
@@ -14,7 +14,8 @@ const encode = function (str) {
  * Special encode a string
  * @param {String} str
  */
- const specialEncode = function (str) {
+const specialEncode = function (str) {
+    if (str === ".") return "";
     return encode(str.replace(/@/g, "a-t-r").replace(/\//g, "s-l-a-s-h").replace(/:/g, "c-o-l-o-n"));
 };
 
@@ -139,7 +140,7 @@ PackageInfo.createK8sAnnotationsForPackage = function (packageObject, parentPack
         annotations[constants.ARGOPM_LIBRARY_REPO_LABEL] = packageObject.repository.url;
     }
 
-    if(packageObject.keywords) {
+    if (packageObject.keywords) {
         annotations[constants.ARGOPM_LIBRARY_KEYWORD_LABEL] = JSON.stringify(packageObject.keywords);
     }
 


### PR DESCRIPTION
When installing pacakges locally, the parentPackage is set to '.' in the labels causing an error during local install via
```
argopm install . -n default
```

Error Message
```
Pipeline.dataflow.argoproj.io "atlan-test-pipeline-louis" is invalid: metadata.labels: Invalid value: ".": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```