### PR TITLE
GOV-956 Prevent failure due to missing numaflow CRD

### DIFF
--- a/lib/k8s.js
+++ b/lib/k8s.js
@@ -155,7 +155,13 @@ class K8sInstaller {
             constants.ARGO_NUMAFLOW_K8S_API_GROUP,
             K8sInstaller.upsertTemplate,
             (yamlData) => yamlData.apiVersion && yamlData.apiVersion.startsWith(constants.ARGO_NUMAFLOW_K8S_API_GROUP)
-        );
+        ).catch((err) => {
+            if (err && err.response && err.response.statusCode == 404) {
+                console.error("Numaflow CRDS Missing from cluster, skipping install");
+            } else {
+                throw err;
+            }
+        });
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argopm",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "argopm",
-      "version": "0.9.4",
+      "version": "0.9.5",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.319.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Kots clusters won't have numaflow installed so don't fail due to missing CRD