### PR TITLE
PES-2672 | Skip installation of @atlan/connectors if a crawler is running

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2020
   },
   "env": {
     "es6": true,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ available for AWS S3)
 
 ### Prerequisites
 
--   Node.js `> v16.9.0`
+-   Node.js `> v18.20.3`
 
 ### Installation
 

--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -179,7 +179,7 @@ function getConnectorPackages() {
         .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
         .filter(file => file.endsWith("package.json"))
         .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
-        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] == 'true')
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] === 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] === 'true')
         .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
         .map(pkg => pkg.name);
 

--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -172,18 +172,15 @@ function getConnectorPackages() {
     //If changes for canary are present in canary deployment, and the crawler is running, then we have to stop installation of @atlan/connectors package
     //Hence if any of these are running, we have to skip the installation of @atlan/connectors package.
 
-    //Read all the connector names from the configMaps directory
-    const connectors = fs
-        .readdirSync(path.join(marketplacePackagesPath, 'packages', 'atlan', 'connectors', 'configMaps'))
-        .filter((file) => file.endsWith(".yaml"))
-        .map(file => file.split('.yaml')[0]);
-
-    //Read all the packages for the connectors
+    //Read all the packages
+    //Check for isVerified, isCertified
+    //Check for type miner, utility and return for custom, connectors etc.
     const packages = fs
         .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
         .filter(file => file.endsWith("package.json"))
-        .filter(file => connectors.some(connector => path.basename(path.dirname(file)) === connector))
         .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' || pkg.config?.labels?.['orchestration.atlan.com/certified'] == true)
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
         .map(pkg => pkg.name);
 
     return packages;

--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -167,6 +167,28 @@ function getPackagesToInstall(packageName, packagesMap, installedPackages, skipV
     return packagesToInstall;
 }
 
+function getConnectorPackages() {
+    //All the connector packages don't have dependency to @atlan/connectors
+    //If changes for canary are present in canary deployment, and the crawler is running, then we have to stop installation of @atlan/connectors package
+    //Hence if any of these are running, we have to skip the installation of @atlan/connectors package.
+
+    //Read all the connector names from the configMaps directory
+    const connectors = fs
+        .readdirSync(path.join(marketplacePackagesPath, 'packages', 'atlan', 'connectors', 'configMaps'))
+        .filter((file) => file.endsWith(".yaml"))
+        .map(file => file.split('.yaml')[0]);
+
+    //Read all the packages for the connectors
+    const packages = fs
+        .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
+        .filter(file => file.endsWith("package.json"))
+        .filter(file => connectors.some(connector => path.basename(path.dirname(file)) === connector))
+        .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
+        .map(pkg => pkg.name);
+
+    return packages;
+}
+
 function installPackages(packages, extraArgs, azureArtifacts) {
     // Install packages
     for (const pkg of packages) {
@@ -203,6 +225,7 @@ async function run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, ch
 
     // Always install numaflow packages since delete-pipelines may have deleted them
     const numaflowPackages = [...packagesToInstall].filter((pkg) => pkg.isNumaflowPackage);
+    const connectorPackages = [...packagesToInstall].includes("@atlan/connectors") ? getConnectorPackages() : [];
     if (packageName != "@atlan/cloud-packages") {
         console.log("Numaflow packages to install: " + numaflowPackages.map((pkg) => pkg.name).join(", "));
         installPackages(numaflowPackages, extraArgs, azureArtifacts);
@@ -217,6 +240,12 @@ async function run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, ch
         for (const runningPackage of runningPackages) {
             if (packagesToInstallNames.includes(runningPackage)) {
                 safeToInstall = false;
+                break;
+            }
+            if(connectorPackages.includes(runningPackage)){
+                //If any of the connector packages are running, then we have to skip the installation of @atlan/connectors package.
+                safeToInstall = false;
+                console.log(`Connector package ${runningPackage} is running. Skipping installation of @atlan/connectors package`);
                 break;
             }
         }

--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -179,7 +179,7 @@ function getConnectorPackages() {
         .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
         .filter(file => file.endsWith("package.json"))
         .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
-        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] == true)
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] == 'true')
         .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
         .map(pkg => pkg.name);
 

--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -179,7 +179,7 @@ function getConnectorPackages() {
         .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
         .filter(file => file.endsWith("package.json"))
         .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
-        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' || pkg.config?.labels?.['orchestration.atlan.com/certified'] == true)
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] == 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] == true)
         .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
         .map(pkg => pkg.name);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
**Background:**

All the connectors, if the change is present in configMaps for Canary release, then for the respective connectors, say Hive there is no dependency specified to @atlan/connectors package.

This makes the condition in local-install.js to fail  due to descrepancy in names of packages.
Package to install -> @atlan/connectors
Package/ Crawler running -> @atlan/hive


```js
(const runningPackage of runningPackages) {
            if (packagesToInstallNames.includes(runningPackage)) {
                safeToInstall = false;
                break;
            }
```

**Solution:**

If the installation package is @atlan/connectors for canary configMap changes.
Then we fetch all the connector names.

```js

function getConnectorPackages() {
    //All the connector packages don't have dependency to @atlan/connectors
    //If changes for canary are present in canary deployment, and the crawler is running, then we have to stop installation of @atlan/connectors package
    //Hence if any of these are running, we have to skip the installation of @atlan/connectors package.

    //Read all the connector names from the configMaps directory
    const connectors = fs
        .readdirSync(path.join(marketplacePackagesPath, 'packages', 'atlan', 'connectors', 'configMaps'))
        .filter((file) => file.endsWith(".yaml"))
        .map(file => file.split('.yaml')[0]);

    //Read all the packages for the connectors
    const packages = fs
        .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
        .filter(file => file.endsWith("package.json"))
        .filter(file => connectors.some(connector => path.basename(path.dirname(file)) === connector))
        .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
        .map(pkg => pkg.name);

    return packages;
}

```

Post the fetch we check if any of the crawlers are running.
If any connectors/crawlers are running, then the installation is skipped.


### Tests ###
- Local testing