### PR TITLE
PES 2672 | Stop Atlan update incase of a Connector Workflow Run

### DIFF
--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -179,7 +179,7 @@ function getConnectorPackages() {
         .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
         .filter(file => file.endsWith("package.json"))
         .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
-        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/verified'] === 'true' && pkg.config?.labels?.['orchestration.atlan.com/certified'] === 'true')
+        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/certified'] === 'true')
         .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
         .map(pkg => pkg.name);
 
@@ -222,7 +222,7 @@ async function run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, ch
 
     // Always install numaflow packages since delete-pipelines may have deleted them
     const numaflowPackages = [...packagesToInstall].filter((pkg) => pkg.isNumaflowPackage);
-    const connectorPackages = [...packagesToInstall].includes("@atlan/connectors") ? getConnectorPackages() : [];
+    const connectorPackages = [...packagesToInstall].find((pkg)=> "@atlan/connectors" === pkg.name ) ? getConnectorPackages() : [];
     if (packageName != "@atlan/cloud-packages") {
         console.log("Numaflow packages to install: " + numaflowPackages.map((pkg) => pkg.name).join(", "));
         installPackages(numaflowPackages, extraArgs, azureArtifacts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.14",
+  "version": "0.10.15",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
### Summary ###

This is the refinement of the Earlier PR here:
https://github.com/atlanhq/argopm/pull/82

Background:

All the connectors, if the change is present in configMaps for Canary release, then for the respective connectors, say Hive there is no dependency specified to @atlan/connectors package.

This makes the condition in local-install.js to fail due to descrepancy in names of packages.
Package to install -> @atlan/connectors
Package/ Crawler running -> @atlan/hive

```js
(const runningPackage of runningPackages) {
            if (packagesToInstallNames.includes(runningPackage)) {
                safeToInstall = false;
                break;
            }
```
            


If the installation package is @atlan/connectors for canary configMap changes.
Then we fetch all the connector names.

```js
function getConnectorPackages() {
    //All the connector packages don't have dependency to @atlan/connectors
    //If changes for canary are present in canary deployment, and the crawler is running, then we have to stop installation of @atlan/connectors package
    //Hence if any of these are running, we have to skip the installation of @atlan/connectors package.

    //Read all the packages
    //Check for isVerified, isCertified
    //Check for type miner, utility and return for custom, connectors etc.
    const packages = fs
        .readdirSync(marketplacePackagesPath, { recursive: true, withFileTypes: false })
        .filter(file => file.endsWith("package.json"))
        .map(file => JSON.parse(fs.readFileSync(path.join(marketplacePackagesPath, file), "utf-8")))
        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/certified'] === 'true')
        .filter(pkg => pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'miner' && pkg.config?.labels?.['orchestration.atlan.com/type'] !== 'utility' )
        .map(pkg => pkg.name);

    return packages;
}