### PR TITLE
PLT-2547: feat: support temporary install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argopm",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argopm",
-      "version": "0.10.17",
+      "version": "0.10.18",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.637.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.17",
+  "version": "0.10.18",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
add flag to support temporary install in local-install script.

`Temporary install` enables package install regardless of version upgrade
It respects `bypassSafetyCheck` (if safety failed,it won't install)
The first local-install run after a run with `temporaryInstall` enabled will install packages regardless of version upgrade, this helps to reset the package

tested
- no version change, temporary install -> installs package with `-temp` suffix
- temporary install, temporary install again -> installs package with `-temp` suffix
- temporary install, without temporary install -> installs package without suffix
- temporary install, without temporary install, without temporary install -> no installation

https://atlanhq.atlassian.net/browse/PLT-2547