### PR TITLE
Fix discussions link in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,5 @@ Refer to [CONTRIBUTING.md](/CONTRIBUTING.md) for more information on contributin
 The project is licensed under the MIT License, see the [LICENSE](LICENSE) file for details.
 
 ## Discussion and Support
-
--   Q&A: [Github Discussions](https://github.com/atlanhq/argopm/discussions)
--   You can also reach out to engineering@atlan.com
+-   For any questions please reach out to engineering@atlan.com
 


### PR DESCRIPTION
Fixes: https://github.com/atlanhq/argopm/issues/65

The GitHub discussions link in ReadMe file is either private or not available:
https://github.com/atlanhq/argopm/discussions

Hence, this PR aims to remove it entirely to avoid confusions.