### PR TITLE
MM-3939 feat: isolate skipVersionCheck param

### DIFF
--- a/bin/local-install.js
+++ b/bin/local-install.js
@@ -223,7 +223,15 @@ function installPackages(packages, extraArgs, azureArtifacts) {
     }
 }
 
-async function run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, channel, snapshotInstall) {
+async function run(
+    packageName,
+    azureArtifacts,
+    bypassSafetyCheck,
+    extraArgs,
+    channel,
+    snapshotInstall,
+    skipVersionCheck
+) {
     const packagesMap = getAllPackagesMap();
     const installedPackages = await getInstalledPackages();
 
@@ -231,7 +239,7 @@ async function run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, ch
         packageName,
         packagesMap,
         installedPackages,
-        bypassSafetyCheck,
+        skipVersionCheck,
         snapshotInstall
     );
     console.log(
@@ -304,8 +312,10 @@ const channel = process.argv[7];
 // snapshotInstall install package regardless of package version
 // It respects bypassSafetyCheck, and added a -snapshot suffix to the version
 const snapshotInstallString = process.argv[8];
+const skipVersionCheckString = process.argv[9];
 
 const bypassSafetyCheck = bypassSafetyCheckString === "true";
 const snapshotInstall = snapshotInstallString === "true";
+const skipVersionCheck = skipVersionCheckString === "true";
 
-run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, channel, snapshotInstall);
+run(packageName, azureArtifacts, bypassSafetyCheck, extraArgs, channel, snapshotInstall, skipVersionCheck);


### PR DESCRIPTION
`skipVersionCheck` used to be bundled with `bypassSafetyCheck`.
we use `bypassSafetyCheck: false` on prod tenants to prevent installing package while there's workflow running.

Aim: We want to make `skipVersionCheck` a standalone configurable parameter,
so that we can disable `bypassSafetyCheck` (if there's running workflow and last update < 24hr) while retain `skipVersionCheck`.

This configuration allows `local-install.js` to install package every 30min (atlan-update schedule) when template-caching is enabled.

https://atlanhq.atlassian.net/browse/MM-3939