### PR TITLE
MM-4380 fix: ensure DOCKERFILE installs the current version of argopm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,6 +27,14 @@ jobs:
       - uses: actions/checkout@v2.2.0
         with:
           fetch-depth: 0
+      - name: Get published version
+        id: get_version
+        run: |
+          ARGOPM_VERSION=$(npm show . version)
+          echo "The published version is: $ARGOPM_VERSION"
+          echo "::set-output name=argopm_version::$ARGOPM_VERSION"
+          # sleep 5 sec to make sure we can install the latest published version from npm in Dockerfile
+          sleep 5
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@master"
@@ -56,3 +64,4 @@ jobs:
           build-args: |
             ACCESS_TOKEN_USR=$GITHUB_ACTOR
             ACCESS_TOKEN_PWD=${{ secrets.ORG_PAT_GITHUB }}
+            ARGOPM_VERSION=${{ steps.get_version.outputs.published_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:20-alpine
 
+ARG ARGOPM_VERSION
+
 RUN mkdir /app
 
 WORKDIR /app
 
 COPY . /app
 
-RUN npm install && npm install . -g 
+RUN npm install argopm@${ARGOPM_VERSION} -g
+
+RUN npm install
 
 ENTRYPOINT ["argopm"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ WORKDIR /app
 
 COPY . /app
 
-RUN npm install argopm -g
-
-RUN npm install
+RUN npm install && npm install . -g 
 
 ENTRYPOINT ["argopm"]


### PR DESCRIPTION
https://atlanhq.atlassian.net/browse/MM-4380

`RUN npm install argopm -g` pulls the argopm from npm, due to the timing, this may installs the older version
e.g. 0.10.20 image has 0.10.19 argopm https://github.com/atlanhq/argopm/actions/runs/12295039100/job/34311084788

Added version arg to make sure we install the current version


