### PR TITLE
APP-6168 : Added Logic to for package parent to be installed

### DIFF
--- a/lib/local-install-util.js
+++ b/lib/local-install-util.js
@@ -108,7 +108,6 @@ function getPackagesToInstall(packageName, packagesMap, installedPackages, skipV
             }
         }
     }
-     
     packagesToInstall.add(package);
     return packagesToInstall;
 }

--- a/lib/local-install-util.js
+++ b/lib/local-install-util.js
@@ -107,9 +107,9 @@ function getPackagesToInstall(packageName, packagesMap, installedPackages, skipV
                 packagesToInstall = new Set([...packagesToInstall, ...dependencyPackagesToInstall]);
             }
         }
-    } else {
-        packagesToInstall.add(package);
     }
+     
+    packagesToInstall.add(package);
     return packagesToInstall;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.10.24",
+  "version": "0.10.25",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes a couple of changes to the `lib/local-install-util.js` and `package.json` files. The most important changes are:

Code logic improvement:

* [`lib/local-install-util.js`](diffhunk://#diff-7a770817ee1ee4e830627993552f9bd9dd05d5292210bc897384b713d45399c2L110-R112): Simplified the logic in `getPackagesToInstall` by removing an unnecessary `else` block and ensuring the package is always added to `packagesToInstall`.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.10.24` to `0.10.25`.