### PR TITLE
security: disable remote-registry fetch, enforce local-only installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Commands:
 Options:
       --version    Show version number                                                                                                 [boolean]
   -n, --namespace  Kubernetes namespace. Packages will be installed in this namespace                                 [string] [default: "argo"]
-  -r, --registry   Argo Package Registry                                                        [string] [default: "https://packages.atlan.com"]
+  -r, --registry   Deprecated no-op. Retained for backward compatibility. argopm only performs local installs.    [string] [default: ""]
   -c, --cluster    Install the template at cluster level                                                              [boolean] [default: false]
       --help       Show help                                                                                                           [boolean]
 ```

--- a/bin/install.js
+++ b/bin/install.js
@@ -192,7 +192,7 @@ yargs
     .option("registry", {
         alias: "r",
         type: "string",
-        description: "Argo Package Registry",
+        description: "Deprecated no-op. Retained for backward compatibility. argopm only performs local installs.",
         default: "",
     })
     .option("cluster", {

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,59 +1,36 @@
 "use strict";
 const Promise = require("bluebird");
-const system = require("system-commands");
 const npa = require("npm-package-arg");
 const K8sInstaller = require("./k8s").K8sInstaller;
 const S3 = require("./s3").S3;
 const listDirs = require("./utils").listDirs;
-const deleteDir = require("./utils").deleteDir;
 const appendToFileSync = require("./utils").appendToFileSync;
 const fs = require("fs");
 const { DashboardInstaller } = require("./dashboard");
 const { constants } = require("./constants");
 
-/**
- * Downloads the given package
- *
- * @param {String} prefixPath Directory to install
- * @param {String} packageName Argo package name
- * @param {String} registry Argo Package registry
- * @param {String} saveParam Save parameter
- */
+const LOCAL_ONLY_ERROR =
+    "argopm only supports local installs. Use 'argopm install .' from a package directory. " +
+    "Remote registry fetch has been disabled.";
+
+// Remote-registry fetching has been removed. argopm installs only from local package directories (`.`).
+// The `registry` and `saveParam` parameters are retained so existing call sites keep working;
+// both are ignored.
+// eslint-disable-next-line no-unused-vars
 const npmInstall = function (prefixPath, packageName, registry, saveParam) {
     if (packageName === ".") {
-        // Local install — skip npm i entirely since dependencies are managed locally
         return Promise.resolve();
     }
-    if (!registry) {
-        return Promise.reject(
-            "No registry specified. A registry URL is required to install remote packages. " +
-            "Use 'argopm install .' for local installs or pass -r <registry-url>."
-        );
-    }
-    return system(`NPM_CONFIG_REGISTRY=${registry} npm i ${packageName} ${saveParam} --prefix ${prefixPath} --force`);
+    return Promise.reject(new Error(LOCAL_ONLY_ERROR));
 };
 
-/**
- * Install a global package
- *
- * @param {string} packageName
- * @param {string} registry
- * @param {string} namespace
- * @param {boolean} cluster
- * @param {{force:boolean,cronString:string,timeZone,preview:boolean,azure:boolean}} options
- */
+// Global install required a remote registry and has been disabled. Signature preserved so
+// `bin/install.js` still resolves the export; calling it always fails closed.
+// eslint-disable-next-line no-unused-vars
 const installGlobal = function (packageName, registry, namespace, cluster, options) {
-    let dirPath = `/tmp/argopm/${packageName}`;
-    dirPath = dirPath.split("@").slice(0, -1).join("@");
-    let mainPackageName = packageName;
-    return install(packageName, registry, namespace, false, cluster, options, dirPath)
-        .then((name) => {
-            mainPackageName = name;
-            return deleteDir(dirPath);
-        })
-        .then((_) => {
-            return mainPackageName;
-        });
+    return Promise.reject(
+        new Error("argopm global install has been disabled. Use local installs ('argopm install .') only.")
+    );
 };
 
 exports.installGlobal = installGlobal;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argopm",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "Argo package manager",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Disables remote-npm-registry fetching in argopm; only `argopm install .` (local folder) is supported.
- `-r/--registry` CLI flag is retained as a **documented no-op** so existing callers (WorkflowTemplate at `marketplace-packages/packages/core/argopm/templates/default.yaml:56`, CI scripts, dev commands) keep parsing.
- `installGlobal` and non-`.` package names now fail-closed with a clear error.
- Version bumped `0.11.3` → `0.12.0` to signal the behavior break.

## Why

Supply-chain incident reported today:

- The `@atlan` npm scope is **unclaimed** on public npmjs.org. Atlan's claimed scope is `@atlanhq`.
- An external actor squatted `@atlan/connectors@99.9.9` on 2026-04-16 with a malicious `preinstall` script that exfiltrates hostname + username via DNS.
- `marketplace-packages` references ~150 `@atlan/*` packages with semver ranges; any `npm install` that isn't pinned to the internal registry can resolve those against public npm and execute the squatted package.
- argopm's `lib/install.js:33` previously ran `NPM_CONFIG_REGISTRY=${registry} npm i ${packageName} ...`. If the passed registry fell through to public npm, the squat executed.

This PR closes argopm's side of the vector by making remote fetch impossible. Follow-ups in `marketplace-packages` (root `.npmrc` pinning + WorkflowTemplate image bump to `v0.12.0`), claiming `@atlan` on npmjs.org, and reporting the malicious package are tracked separately.

## Changes

- **`lib/install.js`**: `npmInstall` now resolves for `.` only and rejects otherwise. `installGlobal` always rejects. Removed `system-commands` / `deleteDir` imports that became unused.
- **`bin/install.js`**: `-r/--registry` description updated to "Deprecated no-op. Retained for backward compatibility. argopm only performs local installs." Flag still parses; value is threaded through but ignored.
- **`package.json`**: `0.12.0`.
- **`README.md`**: rendered help snippet for `-r` updated.

## Test plan

- [x] `npm test` — `tests/base.test.js` 4/4 pass (the other suite's pre-existing Jest+ESM failure in `@kubernetes/client-node` is unrelated).
- [x] `grep -rn 'NPM_CONFIG_REGISTRY\|npm i \|npm install' lib/ bin/` returns no executable matches.
- [x] `argopm install --help` shows the new "Deprecated no-op" description for `-r`.
- [x] `argopm install . -r https://attacker.example.com --preview` → succeeds in preview, `-r` ignored, no outbound HTTP (exit 0).
- [x] `argopm install @atlan/connectors -r https://registry.npmjs.org` → fail-closed error, exit 1.
- [x] `argopm install @atlan/connectors -g -r https://packages.atlan.com` → "argopm global install has been disabled", exit 1.
